### PR TITLE
fix: change android api level to 24

### DIFF
--- a/profiles/aarch64-android-debug-clang-14
+++ b/profiles/aarch64-android-debug-clang-14
@@ -6,7 +6,7 @@ compiler.version = 14
 build_type = Debug
 
 compiler.libcxx = c++_static
-os.api_level = 29
+os.api_level = 24
 
 [tool_requires]
 *: android-ndk/r25

--- a/profiles/aarch64-android-release-clang-14
+++ b/profiles/aarch64-android-release-clang-14
@@ -6,7 +6,7 @@ compiler.version = 14
 build_type = Release
 
 compiler.libcxx = c++_static
-os.api_level = 29
+os.api_level = 24
 
 [tool_requires]
 *: android-ndk/r25

--- a/profiles/aarch64-android-relwithdebinfo-clang-14
+++ b/profiles/aarch64-android-relwithdebinfo-clang-14
@@ -6,7 +6,7 @@ compiler.version = 14
 build_type = RelWithDebInfo
 
 compiler.libcxx = c++_static
-os.api_level = 29
+os.api_level = 24
 
 [tool_requires]
 *: android-ndk/r25

--- a/templates/android.jinja
+++ b/templates/android.jinja
@@ -6,7 +6,7 @@ compiler.version = {{ compiler.version }}
 build_type = {{ build_type }}
 
 compiler.libcxx = c++_static
-os.api_level = 29
+os.api_level = 24
 
 [tool_requires]
 *: android-ndk/r25


### PR DESCRIPTION
In order to build for HereLink Android platform we have to lower API level to 24